### PR TITLE
ffmpy 0.3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,16 @@ source:
   sha256: 757591581eee25b4a50ac9ffb9b58035a2794533db47e0512f53fb2d7b6f9adc
 
 build:
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - ffmpeg
   run:
-    - python >=3.6
+    - python
     - ffmpeg
 
 test:
@@ -34,8 +33,15 @@ test:
 about:
   home: https://github.com/Ch00k/ffmpy
   summary: A simple Python wrapper for ffmpeg
+  description: |
+    ffmpy is a simple FFmpeg command line wrapper.
+    It implements a Pythonic interface for FFmpeg command line compilation
+    and uses Python's subprocess to execute the compiled command line.
   license: MIT
   license_file: LICENSE
+  license_family: MIT
+  doc_url: https://ffmpy.readthedocs.io/
+  dev_url: https://github.com/Ch00k/ffmpy
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**Destination channel:** defaults

### Links

- [PKG-10749](https://anaconda.atlassian.net/browse/PKG-10749)
- [Upstream repository](https://github.com/Ch00k/ffmpy)
- [Upstream changelog/diff](https://github.com/Ch00k/ffmpy/releases)
- Relevant dependency PRs:
  - [PKG-10274](https://anaconda.atlassian.net/browse/PKG-10274)

### Explanation of changes:

- Fork from Conda Forge
- Remove noarch and add linter fixes
- New update not needed at this time since gradio has no version requirements. Also we don't have uv_build which is needed for the latest ffmpy


[PKG-10749]: https://anaconda.atlassian.net/browse/PKG-10749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-10274]: https://anaconda.atlassian.net/browse/PKG-10274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ